### PR TITLE
Change URLs and repo name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 before_install:
   - ./script/install-bats.sh
-  - git clone --depth 1 https://github.com/ztombol/bats-support ../bats-support
+  - git clone --depth 1 https://github.com/bats-core/bats-support ../bats-support
 before_script:
   - export PATH="${HOME}/.local/bin:${PATH}"
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `npm` support
 
 
-[0.2.0]: https://github.com/ztombol/bats-file/compare/v0.1.0...v0.2.0
+[0.2.0]: https://github.com/bats-core/bats-file/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # bats-file
 
-[![GitHub license](https://img.shields.io/badge/license-CC0-blue.svg)](https://raw.githubusercontent.com/peshay/bats-file/master/LICENSE)
-[![GitHub release](https://img.shields.io/github/release/peshay/bats-file.svg)](https://github.com/peshay/bats-file/releases/latest)
-[![Build Status](https://travis-ci.org/peshay/bats-file.svg?branch=master)](https://travis-ci.org/peshay/bats-file)
+[![GitHub license](https://img.shields.io/badge/license-CC0-blue.svg)](https://raw.githubusercontent.com/bats-core/bats-file/master/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/bats-core/bats-file.svg)](https://github.com/bats-core/bats-file/releases/latest)
+[![Build Status](https://travis-ci.org/bats-core/bats-file.svg?branch=master)](https://travis-ci.org/bats-core/bats-file)
 
 `bats-file` is a helper library providing common filesystem related
 assertions and helpers for [Bats][bats].
@@ -950,8 +950,8 @@ path : <temp>/path/to/non-existent-file
 
 <!-- REFERENCES -->
 
-[bats]: https://github.com/sstephenson/bats
-[bats-support-output]: https://github.com/ztombol/bats-support#output-formatting
-[bats-support]: https://github.com/ztombol/bats-support
+[bats]: https://github.com/bats-core/bats-core
+[bats-support-output]: https://github.com/bats-core/bats-support#output-formatting
+[bats-support]: https://github.com/bats-core/bats-support
 [bats-docs]: https://github.com/ztombol/bats-docs
 [bash-pe]: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.2.0",
   "private": true,
   "peerDependencies": {
-    "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.3.0"
+    "bats-support": "git+https://github.com/bats-core/bats-support.git#v0.3.0"
   }
 }

--- a/script/install-bats.sh
+++ b/script/install-bats.sh
@@ -2,5 +2,5 @@
 set -o errexit
 set -o xtrace
 
-git clone --depth 1 https://github.com/sstephenson/bats
-cd bats && ./install.sh "${HOME}/.local" && cd .. && rm -rf bats
+git clone --depth 1 https://github.com/bats-core/bats-core
+cd bats-core && ./install.sh "${HOME}/.local" && cd .. && rm -rf bats-core


### PR DESCRIPTION
Changed the URLs and repo names for the repos that have been transferred to bats-core (https://github.com/bats-core/bats-core/issues/276). Updated in docs, travis spec, and install script.