### PR TITLE
Remove temp directory forcefully.

### DIFF
--- a/src/temp.bash
+++ b/src/temp.bash
@@ -168,7 +168,7 @@ temp_del() {
 
   # Delete directory.
   local result
-  result="$(rm -r -- "$path" 2>&1)"
+  result="$(rm -f -r -- "$path" 2>&1)"
   if (( $? )); then
     echo "$result" \
       | batslib_decorate 'ERROR: temp_del' \


### PR DESCRIPTION
On MacOS if the temp directory contains readonly files. The rm will be hang and ask for an override