### PR TITLE
Renames assertions for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ load this library.
 
 | Test File Types | Test File Attributes | Test File Content |
 | ----------- | ----------- | ----------- |
-| _Check if a **file or directory** exist!_ <br/> - [assert_exist](#assert_exist) <br/> - [assert_not_exist](#assert_not_exist) | _Check if file is **executable**!_ <br/> - [assert_file_executable](#assert_file_executable) <br/> - [assert_file_not_executable](#assert_file_not_executable) | _Check if file is **empty**!_ <br/> - [assert_file_empty](#assert_file_empty) <br/> - [assert_file_not_empty](#assert_file_not_empty) |
-| _Check if a **file** exist!_ <br/> - [assert_file_exist](#assert_file_exist) <br/> - [assert_file_not_exist](#assert_file_not_exist) | _Check the **owner** of a file!_ <br/> - [assert_file_owner](#assert_file_owner) <br/> - [assert_file_not_owner](#assert_file_not_owner) | _Check if file **contains regex**!_ <br/>  - [assert_file_contains](#assert_file_contains) <br/> - ~~assert_file_not_contains~~ |
-| _Check if a **directory** exist!_ <br/> - [assert_dir_exist](#assert_dir_exist) <br/> - [assert_dir_not_exist](#assert_dir_not_exist) | _Check the **permission** of a file!_ <br/> - [assert_file_permission](#assert_file_permission) <br/> - [assert_not_file_permission](#assert_not_file_permission) | _Check if file is a **symlink to target**!_ <br/> - [assert_symlink_to](#assert_symlink_to) <br/> - [assert_not_symlink_to](#assert_not_symlink_to) |
-| _Check if a **link** exist!_ <br/> - [assert_link_exist](#assert_link_exist) <br/> - [assert_link_not_exist](#assert_link_not_exist) | _Check the **size** of a file **by bytes**!_ <br/> - [assert_file_size_equals](#assert_file_size_equals) |
-| _Check if a **block special file** exist!_ <br/> - [assert_block_exist](#assert_block_exist) <br/> - [assert_block_not_exist](#assert_block_not_exist) | _Check if a file have **zero bytes**!_ <br/> - [assert_size_zero](#assert_size_zero) <br/> - [assert_size_not_zero](#assert_size_not_zero) |
-| _Check if a **character special file** exist!_ <br/> - [assert_character_exist](#assert_character_exist) <br/> - [assert_character_not_exist](#assert_character_not_exist) | _Check the **groupID** of a file!_ <br/> - [assert_file_group_id_set](#assert_file_group_id_set) <br/> - [assert_file_not_group_id_set](#assert_file_not_group_id_set) |
-| _Check if a **socket** exist!_ <br/> - [assert_socket_exist](#assert_socket_exist) <br/> - [assert_socket_not_exist](#assert_socket_not_exist) | _Check the **userID** of a file!_ <br/> - [assert_file_user_id_set](#assert_file_user_id_set) <br/> - [assert_file_not_user_id_set](#assert_file_not_user_id_set) |
-| _Check if a **fifo special file** exist!_ <br/> - [assert_fifo_exist](#assert_fifo_exist) <br/> - [assert_fifo_not_exist](#assert_fifo_not_exist) | _Check if a **stickybit is set**!_ <br/> - [assert_sticky_bit](#assert_sticky_bit) <br/> - [assert_no_sticky_bit](#assert_no_sticky_bit) |
+| _Check if a **file or directory** exist!_ <br/> - [assert_exists](#assert_exist) <br/> - [assert_not_exists](#assert_not_exist) | _Check if file is **executable**!_ <br/> - [assert_file_executable](#assert_file_executable) <br/> - [assert_file_not_executable](#assert_file_not_executable) | _Check if file is **empty**!_ <br/> - [assert_file_empty](#assert_file_empty) <br/> - [assert_file_not_empty](#assert_file_not_empty) |
+| _Check if a **file** exist!_ <br/> - [assert_file_exists](#assert_file_exist) <br/> - [assert_file_not_exists](#assert_file_not_exist) | _Check the **owner** of a file!_ <br/> - [assert_file_owner](#assert_file_owner) <br/> - [assert_file_not_owner](#assert_file_not_owner) | _Check if file **contains regex**!_ <br/>  - [assert_file_contains](#assert_file_contains) <br/> - ~~assert_file_not_contains~~ |
+| _Check if a **directory** exist!_ <br/> - [assert_dir_exists](#assert_dir_exist) <br/> - [assert_dir_not_exists](#assert_dir_not_exist) | _Check the **permission** of a file!_ <br/> - [assert_file_permission](#assert_file_permission) <br/> - [assert_not_file_permission](#assert_not_file_permission) | _Check if file is a **symlink to target**!_ <br/> - [assert_symlink_to](#assert_symlink_to) <br/> - [assert_not_symlink_to](#assert_not_symlink_to) |
+| _Check if a **link** exist!_ <br/> - [assert_link_exists](#assert_link_exist) <br/> - [assert_link_not_exists](#assert_link_not_exist) | _Check the **size** of a file **by bytes**!_ <br/> - [assert_file_size_equals](#assert_file_size_equals) |
+| _Check if a **block special file** exist!_ <br/> - [assert_block_exists](#assert_block_exist) <br/> - [assert_block_not_exists](#assert_block_not_exist) | _Check if a file have **zero bytes**!_ <br/> - [assert_size_zero](#assert_size_zero) <br/> - [assert_size_not_zero](#assert_size_not_zero) |
+| _Check if a **character special file** exist!_ <br/> - [assert_character_exists](#assert_character_exist) <br/> - [assert_character_not_exists](#assert_character_not_exist) | _Check the **groupID** of a file!_ <br/> - [assert_file_group_id_set](#assert_file_group_id_set) <br/> - [assert_file_not_group_id_set](#assert_file_not_group_id_set) |
+| _Check if a **socket** exist!_ <br/> - [assert_socket_exists](#assert_socket_exist) <br/> - [assert_socket_not_exists](#assert_socket_not_exist) | _Check the **userID** of a file!_ <br/> - [assert_file_user_id_set](#assert_file_user_id_set) <br/> - [assert_file_not_user_id_set](#assert_file_not_user_id_set) |
+| _Check if a **fifo special file** exist!_ <br/> - [assert_fifo_exists](#assert_fifo_exist) <br/> - [assert_fifo_not_exists](#assert_fifo_not_exist) | _Check if a **stickybit is set**!_ <br/> - [assert_sticky_bit](#assert_sticky_bit) <br/> - [assert_no_sticky_bit](#assert_no_sticky_bit) |
 
 
 ## **Usage**
@@ -43,13 +43,13 @@ load this library.
 ## _Test File Types:_
 
 
-### `assert_exist`
+### `assert_exists`
 
 Fail if the given file or directory does not exist.
 
 ```bash
-@test 'assert_exist()' {
-  assert_exist /path/to/non-existent-file-or-dir
+@test 'assert_exists()' {
+  assert_exists /path/to/non-existent-file-or-dir
 }
 ```
 
@@ -63,13 +63,13 @@ path : /path/to/non-existent-file-or-dir
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_not_exist`
+### `assert_not_exists`
 
 Fail if the given file or directory does exist.
 
 ```bash
-@test 'assert_not_exist()' {
-  assert_not_exist /path/to/existent-file-or-dir
+@test 'assert_not_exists()' {
+  assert_not_exists /path/to/existent-file-or-dir
 }
 ```
 
@@ -85,13 +85,13 @@ path : /path/to/existent-file-or-dir
 ---
 
 
-### `assert_file_exist`
+### `assert_file_exists`
 
 Fail if the given file does not exist.
 
 ```bash
-@test 'assert_file_exist()' {
-  assert_file_exist /path/to/non-existent-file
+@test 'assert_file_exists()' {
+  assert_file_exists /path/to/non-existent-file
 }
 ```
 
@@ -105,13 +105,13 @@ path : /path/to/non-existent-file
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_file_not_exist`
+### `assert_file_not_exists`
 
 Fail if the given file or directory exists.
 
 ```bash
-@test 'assert_file_not_exist() {
-  assert_file_not_exist /path/to/existing-file
+@test 'assert_file_not_exists() {
+  assert_file_not_exists /path/to/existing-file
 }
 ```
 
@@ -127,13 +127,13 @@ path : /path/to/existing-file
 ---
 
 
-### `assert_dir_exist`
+### `assert_dir_exists`
 
 Fail if the given directory does not exist.
 
 ```bash
-@test 'assert_dir_exist()' {
-  assert_file_exist /path/to/non-existent-directory
+@test 'assert_dir_exists()' {
+  assert_file_exists /path/to/non-existent-directory
 }
 ```
 
@@ -147,13 +147,13 @@ path : /path/to/non-existent-directory
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_dir_not_exist`
+### `assert_dir_not_exists`
 
 Fail if the given directory exists.
 
 ```bash
-@test 'assert_dir_not_exist() {
-  assert_dir_not_exist /path/to/existing-directory
+@test 'assert_dir_not_exists() {
+  assert_dir_not_exists /path/to/existing-directory
 }
 ```
 
@@ -169,13 +169,13 @@ path : /path/to/existing-directory
 ---
 
 
-### `assert_link_exist`
+### `assert_link_exists`
 
 Fail if the given symbolic link does not exist.
 
 ```bash
-@test 'assert_link_exist()' {
-  assert_file_exist /path/to/non-existent-link-file
+@test 'assert_link_exists()' {
+  assert_file_exists /path/to/non-existent-link-file
 }
 ```
 
@@ -189,13 +189,13 @@ path : /path/to/non-existent-link-file
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_link_not_exist`
+### `assert_link_not_exists`
 
 Fail if the given symbolic link exists.
 
 ```bash
-@test 'assert_link_not_exist() {
-  assert_file_not_exist /path/to/existing-link-file
+@test 'assert_link_not_exists() {
+  assert_file_not_exists /path/to/existing-link-file
 }
 ```
 
@@ -211,13 +211,13 @@ path : /path/to/existing-link-file
 ---
 
 
-### `assert_block_exist`
+### `assert_block_exists`
 
 Fail if the given block special file does not exist.
 
 ```bash
-@test 'assert_block_exist()' {
-  assert_file_exist /path/to/non-existent-block-file
+@test 'assert_block_exists()' {
+  assert_file_exists /path/to/non-existent-block-file
 }
 ```
 
@@ -231,13 +231,13 @@ path : /path/to/non-existent-block-file
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_block_not_exist`
+### `assert_block_not_exists`
 
 Fail if the given block special file exists.
 
 ```bash
-@test 'assert_block_not_exist() {
-  assert_file_not_exist /path/to/existing-block-file
+@test 'assert_block_not_exists() {
+  assert_file_not_exists /path/to/existing-block-file
 }
 ```
 
@@ -253,13 +253,13 @@ path : /path/to/existing-block-file
 ---
 
 
-### `assert_character_exist`
+### `assert_character_exists`
 
 Fail if the given character special file does not exist.
 
 ```bash
-@test 'assert_character_exist()' {
-  assert_file_exist /path/to/non-existent-character-file
+@test 'assert_character_exists()' {
+  assert_file_exists /path/to/non-existent-character-file
 }
 ```
 
@@ -273,13 +273,13 @@ path : /path/to/non-existent-character-file
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_character_not_exist`
+### `assert_character_not_exists`
 
 Fail if the given character special file exists.
 
 ```bash
-@test 'assert_character_not_exist() {
-  assert_file_not_exist /path/to/existing-character-file
+@test 'assert_character_not_exists() {
+  assert_file_not_exists /path/to/existing-character-file
 }
 ```
 
@@ -295,13 +295,13 @@ path : /path/to/existing-character-file
 ---
 
 
-### `assert_socket_exist`
+### `assert_socket_exists`
 
 Fail if the given socket does not exist.
 
 ```bash
-@test 'assert_socket_exist()' {
-  assert_file_exist /path/to/non-existent-socket
+@test 'assert_socket_exists()' {
+  assert_file_exists /path/to/non-existent-socket
 }
 ```
 
@@ -315,13 +315,13 @@ path : /path/to/non-existent-socket
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_socket_not_exist`
+### `assert_socket_not_exists`
 
 Fail if the given socket exists.
 
 ```bash
-@test 'assert_socket_not_exist() {
-  assert_file_not_exist /path/to/existing-socket
+@test 'assert_socket_not_exists() {
+  assert_file_not_exists /path/to/existing-socket
 }
 ```
 
@@ -337,13 +337,13 @@ path : /path/to/existing-socket
 ---
 
 
-### `assert_fifo_exist`
+### `assert_fifo_exists`
 
 Fail if the given named pipe does not exist.
 
 ```bash
-@test 'assert_fifo_exist()' {
-  assert_file_exist /path/to/non-existent-fifo-file
+@test 'assert_fifo_exists()' {
+  assert_file_exists /path/to/non-existent-fifo-file
 }
 ```
 
@@ -357,13 +357,13 @@ path : /path/to/non-existent-fifo-file
 [Back to index](#Index-of-all-functions)
 
 
-### `assert_fifo_not_exist`
+### `assert_fifo_not_exists`
 
 Fail if the given named pipe exists.
 
 ```bash
-@test 'assert_fifo_not_exist()' {
-  assert_file_not_exist /path/to/existing-fifo-file
+@test 'assert_fifo_not_exists()' {
+  assert_file_not_exists /path/to/existing-fifo-file
 }
 ```
 
@@ -930,8 +930,8 @@ setup {
   BATSLIB_FILE_PATH_ADD='<temp>'
 }
 
-@test 'assert_file_exist()' {
-  assert_file_exist "${TEST_TEMP_DIR}/path/to/non-existent-file"
+@test 'assert_file_exists()' {
+  assert_file_exists "${TEST_TEMP_DIR}/path/to/non-existent-file"
 }
 
 teardown() {

--- a/src/file.bash
+++ b/src/file.bash
@@ -26,7 +26,7 @@
 #
 
 # Fail and display path of the file or directory if it does not exist.
-# This function is the logical complement of `assert_not_exist'.
+# This function is the logical complement of `assert_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -38,7 +38,7 @@
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_exist() {
+assert_exists() {
   local -r file="$1"
   if [[ ! -e "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -50,7 +50,7 @@ assert_exist() {
 }
 
 # Fail and display path of the file if it does not exist.
-# This function is the logical complement of `assert_file_not_exist'.
+# This function is the logical complement of `assert_file_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -62,7 +62,7 @@ assert_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_file_exist() {
+assert_file_exists() {
   local -r file="$1"
   if [[ ! -f "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -74,7 +74,7 @@ assert_file_exist() {
 }
 
 # Fail and display path of the directory if it does not exist.
-# This function is the logical complement of `assert_dir_not_exist'.
+# This function is the logical complement of `assert_dir_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -86,7 +86,7 @@ assert_file_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_dir_exist() {
+assert_dir_exists() {
   local -r file="$1"
   if [[ ! -d "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -98,7 +98,7 @@ assert_dir_exist() {
 }
 
 # Fail and display path of the block special file if it does not exist.
-# This function is the logical complement of `assert_block_not_exist'.
+# This function is the logical complement of `assert_block_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -110,7 +110,7 @@ assert_dir_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_block_exist() {
+assert_block_exists() {
   local -r file="$1"
   if [[ ! -b "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -122,7 +122,7 @@ assert_block_exist() {
 }
 
 # Fail and display path of the character special file if it does not exist.
-# This function is the logical complement of `assert_character_not_exist'.
+# This function is the logical complement of `assert_character_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -134,7 +134,7 @@ assert_block_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_character_exist() {
+assert_character_exists() {
   local -r file="$1"
   if [[ ! -c "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -146,7 +146,7 @@ assert_character_exist() {
 }
 
 # Fail and display path of the symbolic link if it does not exist.
-# This function is the logical complement of `assert_link_not_exist'.
+# This function is the logical complement of `assert_link_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -158,7 +158,7 @@ assert_character_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_link_exist() {
+assert_link_exists() {
   local -r file="$1"
   if [[ ! -L "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -170,7 +170,7 @@ assert_link_exist() {
 }
 
 # Fail and display path of the socket if it does not exist.
-# This function is the logical complement of `assert_socket_not_exist'.
+# This function is the logical complement of `assert_socket_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -182,7 +182,7 @@ assert_link_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_socket_exist() {
+assert_socket_exists() {
   local -r file="$1"
   if [[ ! -S "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -194,7 +194,7 @@ assert_socket_exist() {
 }
 
 # Fail and display path of the named pipe if it does not exist.
-# This function is the logical complement of `assert_fifo_not_exist'.
+# This function is the logical complement of `assert_fifo_not_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -206,7 +206,7 @@ assert_socket_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_fifo_exist() {
+assert_fifo_exists() {
   local -r file="$1"
   if [[ ! -p "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -586,7 +586,7 @@ assert_file_empty() {
   fi
 }
 # Fail and display path of the file (or directory) if it exists. This
-# function is the logical complement of `assert_exist'.
+# function is the logical complement of `assert_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -598,7 +598,7 @@ assert_file_empty() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_not_exist() {
+assert_not_exists() {
   local -r file="$1"
   if [[ -e "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -610,7 +610,7 @@ assert_not_exist() {
 }
 
 # Fail and display path of the file if it exists. This
-# function is the logical complement of `assert_file_exist'.
+# function is the logical complement of `assert_file_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -622,7 +622,7 @@ assert_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_file_not_exist() {
+assert_file_not_exists() {
   local -r file="$1"
   if [[ -f "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -634,7 +634,7 @@ assert_file_not_exist() {
 }
 
 # Fail and display path of the directory if it exists. This
-# function is the logical complement of `assert_dir_exist'.
+# function is the logical complement of `assert_dir_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -646,7 +646,7 @@ assert_file_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_dir_not_exist() {
+assert_dir_not_exists() {
   local -r file="$1"
   if [[ -d "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -658,7 +658,7 @@ assert_dir_not_exist() {
 }
 
 # Fail and display path of the block special file if it exists. This
-# function is the logical complement of `assert_block_exist'.
+# function is the logical complement of `assert_block_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -670,7 +670,7 @@ assert_dir_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_block_not_exist() {
+assert_block_not_exists() {
   local -r file="$1"
   if [[ -b "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -682,7 +682,7 @@ assert_block_not_exist() {
 }
 
 # Fail and display path of the character special file if it exists. This
-# function is the logical complement of `assert_character_exist'.
+# function is the logical complement of `assert_character_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -694,7 +694,7 @@ assert_block_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_character_not_exist() {
+assert_character_not_exists() {
   local -r file="$1"
   if [[ -c "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -706,7 +706,7 @@ assert_character_not_exist() {
 }
 
 # Fail and display path of the symbolic link if it exists. This
-# function is the logical complement of `assert_link_exist'.
+# function is the logical complement of `assert_link_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -718,7 +718,7 @@ assert_character_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_link_not_exist() {
+assert_link_not_exists() {
   local -r file="$1"
   if [[ -L "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -730,7 +730,7 @@ assert_link_not_exist() {
 }
 
 # Fail and display path of the socket if it exists. This
-# function is the logical complement of `assert_socket_exist'.
+# function is the logical complement of `assert_socket_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -742,7 +742,7 @@ assert_link_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_socket_not_exist() {
+assert_socket_not_exists() {
   local -r file="$1"
   if [[ -S "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -754,7 +754,7 @@ assert_socket_not_exist() {
 }
 
 # Fail and display path of the named pipe if it exists. This
-# function is the logical complement of `assert_fifo_exist'.
+# function is the logical complement of `assert_fifo_exists'.
 #
 # Globals:
 #   BATSLIB_FILE_PATH_REM
@@ -766,7 +766,7 @@ assert_socket_not_exist() {
 #   1 - otherwise
 # Outputs:
 #   STDERR - details, on failure
-assert_fifo_not_exist() {
+assert_fifo_not_exists() {
   local -r file="$1"
   if [[ -p "$file" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
@@ -1091,3 +1091,19 @@ assert_file_not_empty() {
       | fail
   fi
 }
+
+# Aliases to old assertion names
+assert_exist() { assert_exists "$@"; }
+assert_not_exist() { assert_not_exists "$@"; }
+assert_file_exist() { assert_file_exists "$@"; }
+assert_file_not_exist() { assert_file_not_exists "$@"; }
+assert_dir_exist() { assert_dir_exists "$@"; }
+assert_dir_not_exist() { assert_dir_not_exists "$@"; }
+assert_link_exist() { assert_link_exists "$@"; }
+assert_link_not_exist() { assert_link_not_exists "$@"; }
+assert_block_exist() { assert_block_exists "$@"; }
+assert_block_not_exist() { assert_block_not_exists "$@"; }
+assert_character_exist() { assert_character_exists "$@"; }
+assert_character_not_exist() { assert_character_not_exists "$@"; }
+assert_fifo_exist() { assert_fifo_exists "$@"; }
+assert_fifo_not_exist() { assert_fifo_not_exists "$@"; }

--- a/test/50-assert-10-assert_exist.bats
+++ b/test/50-assert-10-assert_exist.bats
@@ -11,23 +11,23 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_exist() <file>: returns 0 if <file> exists' {
+@test 'assert_exists() <file>: returns 0 if <file> exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_exist "$file"
+  run assert_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_exist() <file>: returns 0 if <directory> exists' {
+@test 'assert_exists() <file>: returns 0 if <directory> exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir"
-  run assert_exist "$file"
+  run assert_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_exist() <file>: returns 1 and displays path if <file> does not exist' {
-  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
-  run assert_exist "$file"
+@test 'assert_exists() <file>: returns 1 and displays path if <file> does not exist' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exists"
+  run assert_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory does not exist --' ]
@@ -36,10 +36,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_exist() <file>: replace prefix of displayed path' {
+@test 'assert_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_exist "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
+  run assert_exists "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory does not exist --' ]
@@ -47,10 +47,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_exist() <file>: replace suffix of displayed path' {
+@test 'assert_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file.does_not_exist'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_exist "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
+  run assert_exists "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory does not exist --' ]
@@ -58,10 +58,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_exist() <file>: replace infix of displayed path' {
+@test 'assert_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_exist "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
+  run assert_exists "${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory does not exist --' ]

--- a/test/50-assert-11-assert_not_exist.bats
+++ b/test/50-assert-11-assert_not_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_not_exist() <file>: returns 0 if <file> does not exist' {
-  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
-  run assert_not_exist "$file"
+@test 'assert_not_exists() <file>: returns 0 if <file> does not exist' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exists"
+  run assert_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_not_exist() <file>: returns 1 and displays path if <file> exists' {
+@test 'assert_not_exists() <file>: returns 1 and displays path if <file> exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_not_exist "$file"
+  run assert_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]

--- a/test/51-assert-10-assert_file_exist.bats
+++ b/test/51-assert-10-assert_file_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_file_exist() <file>: returns 0 if <file> exists' {
+@test 'assert_file_exists() <file>: returns 0 if <file> exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_file_exist "$file"
+  run assert_file_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_file_exist() <file>: returns 1 and displays path if <file> does not exist' {
+@test 'assert_file_exists() <file>: returns 1 and displays path if <file> does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir"
-  run assert_file_exist "$file"
+  run assert_file_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file does not exist --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_file_exist() <file>: replace prefix of displayed path' {
+@test 'assert_file_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_file_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_file_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file does not exist --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_file_exist() <file>: replace suffix of displayed path' {
-  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exist'
+@test 'assert_file_exists() <file>: replace suffix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exists'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_file_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_file_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file does not exist --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_file_exist() <file>: replace infix of displayed path' {
+@test 'assert_file_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_file_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_file_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file does not exist --' ]

--- a/test/51-assert-11-assert_file_not_exist.bats
+++ b/test/51-assert-11-assert_file_not_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_not_exist() <file>: returns 0 if <file> does not exist' {
-  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
-  run assert_not_exist "$file"
+@test 'assert_not_exists() <file>: returns 0 if <file> does not exist' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exists"
+  run assert_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_not_exist() <file>: returns 1 and displays path if <file> exists' {
+@test 'assert_not_exists() <file>: returns 1 and displays path if <file> exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_not_exist "$file"
+  run assert_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_not_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_not_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- file or directory exists, but it was expected to be absent --' ]

--- a/test/52-assert-10-assert_file_executeable.bats
+++ b/test/52-assert-10-assert_file_executeable.bats
@@ -43,7 +43,7 @@ teardown () {
 }
 
 @test 'assert_file_executable() <file>: replace suffix of displayed path' {
-  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exist'
+  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exists'
   local -r BATSLIB_FILE_PATH_ADD='..'
   run assert_file_executable "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]

--- a/test/53-assert-10-assert_link_exist.bats
+++ b/test/53-assert-10-assert_link_exist.bats
@@ -14,16 +14,16 @@ teardown () {
 
 
 # Correctness
-@test 'assert_link_exist() <file>: returns 0 if <file> Link exists' {
+@test 'assert_link_exists() <file>: returns 0 if <file> Link exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/link"
-  run assert_link_exist "$file"
+  run assert_link_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_link_exist() <file>: returns 1 and displays path if <file>symbolic link does not exist' {
+@test 'assert_link_exists() <file>: returns 1 and displays path if <file>symbolic link does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/ "
-  run assert_link_exist "$file"
+  run assert_link_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link does not exist --' ]
@@ -32,10 +32,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_link_exist() <file>: replace prefix of displayed path' {
+@test 'assert_link_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_link_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link does not exist --' ]
@@ -43,10 +43,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_link_exist() <file>: replace suffix of displayed path' {
-  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exist'
+@test 'assert_link_exists() <file>: replace suffix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exists'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_link_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link does not exist --' ]
@@ -54,10 +54,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_link_exist() <file>: replace infix of displayed path' {
+@test 'assert_link_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='nodir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_link_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link does not exist --' ]

--- a/test/53-assert-11-assert_link_not_exist.bats
+++ b/test/53-assert-11-assert_link_not_exist.bats
@@ -14,16 +14,16 @@ teardown () {
 
 
 # Correctness
-@test 'assert_link_not_exist() <file>: returns 0 if <file> is not a link' {
+@test 'assert_link_not_exists() <file>: returns 0 if <file> is not a link' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_link_not_exist "$file"
+  run assert_link_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_link_not_exist() <file>: returns 1 and displays path if <file> symbolic link exists, but it was expected to be absent' {
+@test 'assert_link_not_exists() <file>: returns 1 and displays path if <file> symbolic link exists, but it was expected to be absent' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/link"
-  run assert_link_not_exist "$file"
+  run assert_link_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   echo "${lines[0]}"  
@@ -33,10 +33,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_link_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_link_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_not_exist "${TEST_FIXTURE_ROOT}/dir/link"
+  run assert_link_not_exists "${TEST_FIXTURE_ROOT}/dir/link"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link exists, but it was expected to be absent --' ]
@@ -44,10 +44,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_link_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_link_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_not_exist "${TEST_FIXTURE_ROOT}/dir/link"
+  run assert_link_not_exists "${TEST_FIXTURE_ROOT}/dir/link"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link exists, but it was expected to be absent --' ]
@@ -55,10 +55,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_link_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_link_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_link_not_exist "${TEST_FIXTURE_ROOT}/dir/link"
+  run assert_link_not_exists "${TEST_FIXTURE_ROOT}/dir/link"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- symbolic link exists, but it was expected to be absent --' ]

--- a/test/54-assert-10-assert_character_exist.bats
+++ b/test/54-assert-10-assert_character_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_character_exist() <file>: returns 0 if <file> character special file exists' {
+@test 'assert_character_exists() <file>: returns 0 if <file> character special file exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/test_device"
-  run assert_character_exist "$file"
+  run assert_character_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_character_exist() <file>: returns 1 and displays path if <file> character special file does not exist' {
+@test 'assert_character_exists() <file>: returns 1 and displays path if <file> character special file does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_character_exist "$file"
+  run assert_character_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file does not exist --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_character_exist() <file>: replace prefix of displayed path' {
+@test 'assert_character_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_character_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file does not exist --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_character_exist() <file>: replace suffix of displayed path' {
-  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exist'
+@test 'assert_character_exists() <file>: replace suffix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM='%file.does_not_exists'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_character_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file does not exist --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_character_exist() <file>: replace infix of displayed path' {
+@test 'assert_character_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='nodir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_exist "${TEST_FIXTURE_ROOT}/nodir"
+  run assert_character_exists "${TEST_FIXTURE_ROOT}/nodir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file does not exist --' ]

--- a/test/54-assert-11-assert_character_not_exist.bats
+++ b/test/54-assert-11-assert_character_not_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_character_not_exist() <file>: returns 0 if <file> character special file does not exist' {
+@test 'assert_character_not_exists() <file>: returns 0 if <file> character special file does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_character_not_exist "$file"
+  run assert_character_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_character_not_exist() <file>: returns 1 and displays path if <file> character special file exists, but it was expected to be absent' {
+@test 'assert_character_not_exists() <file>: returns 1 and displays path if <file> character special file exists, but it was expected to be absent' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/test_device"
-  run assert_character_not_exist "$file"
+  run assert_character_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file exists, but it was expected to be absent --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_character_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_character_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_not_exist "${TEST_FIXTURE_ROOT}/dir/test_device"
+  run assert_character_not_exists "${TEST_FIXTURE_ROOT}/dir/test_device"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file exists, but it was expected to be absent --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_character_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_character_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_not_exist "${TEST_FIXTURE_ROOT}/dir/test_device"
+  run assert_character_not_exists "${TEST_FIXTURE_ROOT}/dir/test_device"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file exists, but it was expected to be absent --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_character_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_character_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_character_not_exist "${TEST_FIXTURE_ROOT}/dir/test_device"
+  run assert_character_not_exists "${TEST_FIXTURE_ROOT}/dir/test_device"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- character special file exists, but it was expected to be absent --' ]

--- a/test/55-assert-10-assert_block_exist.bats
+++ b/test/55-assert-10-assert_block_exist.bats
@@ -10,16 +10,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_block_exist() <file>: returns 0 if <file> block special file exists' {
+@test 'assert_block_exists() <file>: returns 0 if <file> block special file exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/blockfile"
-  run assert_block_exist "$file"
+  run assert_block_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ] 
 }
 
-@test 'assert_block_exist() <file>: returns 1 and displays path if <file> block special file does not exist' {
+@test 'assert_block_exists() <file>: returns 1 and displays path if <file> block special file does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_block_exist "$file"
+  run assert_block_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file does not exist --' ]
@@ -28,10 +28,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_block_exist() <file>: replace prefix of displayed path' {
+@test 'assert_block_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_block_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file does not exist --' ]
@@ -39,10 +39,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_block_exist() <file>: replace suffix of displayed path' {
+@test 'assert_block_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_block_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file does not exist --' ]
@@ -50,10 +50,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_block_exist() <file>: replace infix of displayed path' {
+@test 'assert_block_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_block_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file does not exist --' ]

--- a/test/55-assert-11-assert_block_not_exist.bats
+++ b/test/55-assert-11-assert_block_not_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_block_not_exist() <file>: returns 0 if <file> block special does not exist' {
+@test 'assert_block_not_exists() <file>: returns 0 if <file> block special does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_block_not_exist "$file"
+  run assert_block_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_block_not_exist() <file>: returns 1 and displays path if <file> block special file exists, but it was expected to be absent' {
+@test 'assert_block_not_exists() <file>: returns 1 and displays path if <file> block special file exists, but it was expected to be absent' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/blockfile"
-  run assert_block_not_exist "$file"
+  run assert_block_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file exists, but it was expected to be absent --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_block_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_block_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_not_exist "${TEST_FIXTURE_ROOT}/dir/blockfile"
+  run assert_block_not_exists "${TEST_FIXTURE_ROOT}/dir/blockfile"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file exists, but it was expected to be absent --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_block_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_block_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%blockfile'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_not_exist "${TEST_FIXTURE_ROOT}/dir/blockfile"
+  run assert_block_not_exists "${TEST_FIXTURE_ROOT}/dir/blockfile"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file exists, but it was expected to be absent --' ]
@@ -52,10 +52,10 @@ teardown () {
 
 }
 
-@test 'assert_block_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_block_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_block_not_exist "${TEST_FIXTURE_ROOT}/dir/blockfile"
+  run assert_block_not_exists "${TEST_FIXTURE_ROOT}/dir/blockfile"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- block special file exists, but it was expected to be absent --' ]

--- a/test/56-assert-10-assert_fifo_exist.bats
+++ b/test/56-assert-10-assert_fifo_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_fifo_exist() <file>: returns 0 if <file> fifo exists' {
+@test 'assert_fifo_exists() <file>: returns 0 if <file> fifo exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/testpipe"
-  run assert_fifo_exist "$file"
+  run assert_fifo_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_fifo_exist() <file>: returns 1 and displays path if <file> fifo does not exist' {
+@test 'assert_fifo_exists() <file>: returns 1 and displays path if <file> fifo does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_fifo_exist "$file"
+  run assert_fifo_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo does not exist --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_fifo_exist() <file>: replace prefix of displayed path' {
+@test 'assert_fifo_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_fifo_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo does not exist --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_fifo_exist() <file>: replace suffix of displayed path' {
+@test 'assert_fifo_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_fifo_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo does not exist --' ]
@@ -51,10 +51,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_fifo_exist() <file>: replace infix of displayed path' {
+@test 'assert_fifo_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_fifo_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo does not exist --' ]

--- a/test/56-assert-11-assert_fifo_not_exist.bats
+++ b/test/56-assert-11-assert_fifo_not_exist.bats
@@ -12,16 +12,16 @@ teardown () {
 
 
 # Correctness
-@test 'assert_fifo_not_exist() <file>: returns 0 if <file> fifo does not exists' {
+@test 'assert_fifo_not_exists() <file>: returns 0 if <file> fifo does not exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_fifo_not_exist "$file"
+  run assert_fifo_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_fifo_not_exist() <file>: returns 1 and displays path if <file> fifo exists, but it was expected to be absent' {
+@test 'assert_fifo_not_exists() <file>: returns 1 and displays path if <file> fifo exists, but it was expected to be absent' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/testpipe"
-  run assert_fifo_not_exist "$file"
+  run assert_fifo_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo exists, but it was expected to be absent --' ]
@@ -30,10 +30,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_fifo_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_fifo_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_not_exist "${TEST_FIXTURE_ROOT}/dir/testpipe"
+  run assert_fifo_not_exists "${TEST_FIXTURE_ROOT}/dir/testpipe"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo exists, but it was expected to be absent --' ]
@@ -41,10 +41,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_fifo_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_fifo_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%testpipe'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_not_exist "${TEST_FIXTURE_ROOT}/dir/testpipe"
+  run assert_fifo_not_exists "${TEST_FIXTURE_ROOT}/dir/testpipe"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo exists, but it was expected to be absent --' ]
@@ -53,10 +53,10 @@ teardown () {
 
 }
 
-@test 'assert_fifo_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_fifo_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_fifo_not_exist "${TEST_FIXTURE_ROOT}/dir/testpipe"
+  run assert_fifo_not_exists "${TEST_FIXTURE_ROOT}/dir/testpipe"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- fifo exists, but it was expected to be absent --' ]

--- a/test/57-assert-10-assert_socket_exist.bats
+++ b/test/57-assert-10-assert_socket_exist.bats
@@ -12,16 +12,16 @@ teardown () {
 
 
 # Correctness
-@test 'assert_socket_exist() <file>: returns 0 if <file> socket exists' {
+@test 'assert_socket_exists() <file>: returns 0 if <file> socket exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/somesocket"
-  run assert_socket_exist "$file"
+  run assert_socket_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_socket_exist() <file>: returns 1 and displays path if <file> socket does not exist' {
+@test 'assert_socket_exists() <file>: returns 1 and displays path if <file> socket does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_socket_exist "$file"
+  run assert_socket_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket does not exist --' ]
@@ -30,10 +30,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_socket_exist() <file>: replace prefix of displayed path' {
+@test 'assert_socket_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_socket_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket does not exist --' ]
@@ -41,10 +41,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_socket_exist() <file>: replace suffix of displayed path' {
+@test 'assert_socket_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%file'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_exist "${TEST_FIXTURE_ROOT}/dir/file"
+  run assert_socket_exists "${TEST_FIXTURE_ROOT}/dir/file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket does not exist --' ]
@@ -52,10 +52,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_socket_exist() <file>: replace infix of displayed path' {
+@test 'assert_socket_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_exist "${TEST_FIXTURE_ROOT}/dir"
+  run assert_socket_exists "${TEST_FIXTURE_ROOT}/dir"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket does not exist --' ]

--- a/test/57-assert-11-assert_socket_not_exist.bats
+++ b/test/57-assert-11-assert_socket_not_exist.bats
@@ -11,16 +11,16 @@ teardown () {
 }
 
 # Correctness
-@test 'assert_socket_not_exist() <file>: returns 0 if <file> socket does not exists' {
+@test 'assert_socket_not_exists() <file>: returns 0 if <file> socket does not exists' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/file"
-  run assert_socket_not_exist "$file"
+  run assert_socket_not_exists "$file"
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_socket_not_exist() <file>: returns 1 and displays path if <file> socket exists, but it was expected to be absent' {
+@test 'assert_socket_not_exists() <file>: returns 1 and displays path if <file> socket exists, but it was expected to be absent' {
   local -r file="${TEST_FIXTURE_ROOT}/dir/somesocket"
-  run assert_socket_not_exist "$file"
+  run assert_socket_not_exists "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket exists, but it was expected to be absent --' ]
@@ -29,10 +29,10 @@ teardown () {
 }
 
 # Transforming path
-@test 'assert_socket_not_exist() <file>: replace prefix of displayed path' {
+@test 'assert_socket_not_exists() <file>: replace prefix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_not_exist "${TEST_FIXTURE_ROOT}/dir/somesocket"
+  run assert_socket_not_exists "${TEST_FIXTURE_ROOT}/dir/somesocket"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket exists, but it was expected to be absent --' ]
@@ -40,10 +40,10 @@ teardown () {
   [ "${lines[2]}" == '--' ]
 }
 
-@test 'assert_socket_not_exist() <file>: replace suffix of displayed path' {
+@test 'assert_socket_not_exists() <file>: replace suffix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='%somesocket'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_not_exist "${TEST_FIXTURE_ROOT}/dir/somesocket"
+  run assert_socket_not_exists "${TEST_FIXTURE_ROOT}/dir/somesocket"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket exists, but it was expected to be absent --' ]
@@ -52,10 +52,10 @@ teardown () {
 
 }
 
-@test 'assert_socket_not_exist() <file>: replace infix of displayed path' {
+@test 'assert_socket_not_exists() <file>: replace infix of displayed path' {
   local -r BATSLIB_FILE_PATH_REM='dir'
   local -r BATSLIB_FILE_PATH_ADD='..'
-  run assert_socket_not_exist "${TEST_FIXTURE_ROOT}/dir/somesocket"
+  run assert_socket_not_exists "${TEST_FIXTURE_ROOT}/dir/somesocket"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
   [ "${lines[0]}" == '-- socket exists, but it was expected to be absent --' ]

--- a/test/65-assert-10-assert_symlink_to.bats
+++ b/test/65-assert-10-assert_symlink_to.bats
@@ -20,7 +20,7 @@ teardown () {
   [ "${#lines[@]}" -eq 0 ]
 }
 @test 'assert_symlink_to() <file> <link>: returns 1 and displays path if <link> is not a symbolic link to <file>' {
-  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exist"
+  local -r file="${TEST_FIXTURE_ROOT}/dir/file.does_not_exists"
   local -r link="${TEST_FIXTURE_ROOT}/symlink"
   run assert_symlink_to $file $link
   [ "$status" -eq 1 ]


### PR DESCRIPTION
One assertion is named (notice the final `s`):

```
assert_file_contains
```

and another (notice the missing `s`):

```
assert_file_exist
```

This is confusing. I suggest that all assertions have a final `s` where it makes sense. E.g. `assert_file_exists`. 

Since existing project are using the old type without the final `s`, aliases are created for those old versions.