### PR TITLE
Allow temp functions to also be run setup_file and teardown_file

### DIFF
--- a/src/temp.bash
+++ b/src/temp.bash
@@ -63,8 +63,10 @@
 temp_make() {
   # Check caller.
   if ! ( batslib_is_caller --indirect 'setup' \
+      || batslib_is_caller --indirect 'setup_file' \
       || batslib_is_caller --indirect "$BATS_TEST_NAME" \
-      || batslib_is_caller --indirect 'teardown' )
+      || batslib_is_caller --indirect 'teardown' \
+      || batslib_is_caller --indirect 'teardown_file' )
   then
     echo "Must be called from \`setup', \`@test' or \`teardown'" \
       | batslib_decorate 'ERROR: temp_make' \
@@ -156,7 +158,9 @@ temp_del() {
     return 0
   elif [[ $BATSLIB_TEMP_PRESERVE_ON_FAILURE == '1' ]]; then
     # Check caller.
-    if ! batslib_is_caller --indirect 'teardown'; then
+    if ! ( batslib_is_caller --indirect 'teardown' \
+        || batslib_is_caller --indirect 'teardown_file' )
+    then
       echo "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" \
         | batslib_decorate 'ERROR: temp_del' \
         | fail

--- a/src/temp.bash
+++ b/src/temp.bash
@@ -161,7 +161,7 @@ temp_del() {
     if ! ( batslib_is_caller --indirect 'teardown' \
         || batslib_is_caller --indirect 'teardown_file' )
     then
-      echo "Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" \
+      echo "Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" \
         | batslib_decorate 'ERROR: temp_del' \
         | fail
       return $?

--- a/test/70-temp-10-temp_make.bats
+++ b/test/70-temp-10-temp_make.bats
@@ -31,12 +31,20 @@ fixtures 'temp'
   bats "${TEST_FIXTURE_ROOT}/temp_make-setup.bats"
 }
 
+@test "temp_make() <var>: works when called from \`setup_file'" {
+  bats "${TEST_FIXTURE_ROOT}/temp_make-setup_file.bats"
+}
+
 @test "temp_make() <var>: works when called from \`@test'" {
   bats "${TEST_FIXTURE_ROOT}/temp_make-test.bats"
 }
 
 @test "temp_make() <var>: works when called from \`teardown'" {
   bats "${TEST_FIXTURE_ROOT}/temp_make-teardown.bats"
+}
+
+@test "temp_make() <var>: works when called from \`teardown_file'" {
+  bats "${TEST_FIXTURE_ROOT}/temp_make-teardown_file.bats"
 }
 
 @test "temp_make() <var>: does not work when called from \`main'" {

--- a/test/70-temp-11-temp_del.bats
+++ b/test/70-temp-11-temp_del.bats
@@ -89,6 +89,17 @@ fixtures 'temp'
   [ -e "$TEST_TEMP_DIR" ]
 }
 
+@test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' works when called from \`teardown_file'" {
+  teardown() { rm -r -- "$TEST_TEMP_DIR"; }
+
+  TEST_TEMP_DIR="$(temp_make)"
+  export TEST_TEMP_DIR
+  run bats "${TEST_FIXTURE_ROOT}/temp_del-teardown_file.bats"
+
+  [ "$status" -eq 1 ]
+  [ -e "$TEST_TEMP_DIR" ]
+}
+
 @test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`main'" {
   teardown() { rm -r -- "$TEST_TEMP_DIR"; }
 
@@ -99,7 +110,7 @@ fixtures 'temp'
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 10 ]
   [ "${lines[6]}" == '# -- ERROR: temp_del --' ]
-  [ "${lines[7]}" == "# Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
+  [ "${lines[7]}" == "# Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
   [ "${lines[8]}" == '# --' ]
 }
 
@@ -113,7 +124,21 @@ fixtures 'temp'
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 10 ]
   [[ ${lines[6]} == *'-- ERROR: temp_del --' ]] || false
-  [[ ${lines[7]} == *"Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]] || false
+  [[ ${lines[7]} == *"Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]] || false
+  [[ ${lines[8]} == *'--' ]] || false
+}
+
+@test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`setup_file'" {
+  teardown() { rm -r -- "$TEST_TEMP_DIR"; }
+
+  TEST_TEMP_DIR="$(temp_make)"
+  export TEST_TEMP_DIR
+  run bats "${TEST_FIXTURE_ROOT}/temp_del-setup_file.bats"
+
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 10 ]
+  [[ ${lines[6]} == *'-- ERROR: temp_del --' ]] || false
+  [[ ${lines[7]} == *"Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]] || false
   [[ ${lines[8]} == *'--' ]] || false
 }
 
@@ -127,6 +152,6 @@ fixtures 'temp'
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 10 ]
   [[ ${lines[6]} == *'-- ERROR: temp_del --' ]] || false
-  [[ ${lines[7]} == *"Must be called from \`teardown' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]] || false
+  [[ ${lines[7]} == *"Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]] || false
   [[ ${lines[8]} == *'--' ]] || false
 }

--- a/test/fixtures/temp/temp_del-setup_file.bats
+++ b/test/fixtures/temp/temp_del-setup_file.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup_file() {
+  local -ir BATSLIB_TEMP_PRESERVE_ON_FAILURE=1
+  temp_del "$TEST_TEMP_DIR"
+}
+
+@test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`setup_file'" {
+  true
+}

--- a/test/fixtures/temp/temp_del-teardown_file.bats
+++ b/test/fixtures/temp/temp_del-teardown_file.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+@test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' works when called from \`teardown_file'" {
+  false
+}
+
+teardown_file() {
+  local -ir BATSLIB_TEMP_PRESERVE_ON_FAILURE=1
+  temp_del "$TEST_TEMP_DIR"
+}

--- a/test/fixtures/temp/temp_make-setup_file.bats
+++ b/test/fixtures/temp/temp_make-setup_file.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+setup_file() {
+  TEST_TEMP_DIR="$(temp_make)"
+}
+
+@test "temp_make() <var>: works when called from \`setup_file'" {
+  true
+}
+
+teardown_file() {
+  rm -r -- "$TEST_TEMP_DIR"
+}

--- a/test/fixtures/temp/temp_make-teardown_file.bats
+++ b/test/fixtures/temp/temp_make-teardown_file.bats
@@ -1,0 +1,12 @@
+#!/usr/bin/env bats
+
+load 'test_helper'
+
+@test "temp_make() <var>: works when called from \`teardown_file'" {
+  true
+}
+
+teardown_file() {
+  TEST_TEMP_DIR="$(temp_make)"
+  rm -r -- "$TEST_TEMP_DIR"
+}


### PR DESCRIPTION
Allow temp_make and temp_del to be run in setup_file and teardown_file

Fixes #35 