### PR TITLE
test_helper.bash: Use bats_load_library to load bats-support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         PATH="$HOME/.local/bin:$PATH"
         bats -v
-        BATS_LIB_PATH="$PWD" bats test
+        BATS_LIB_PATH="$PWD" bats --print-output-on-failure test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: ./script/install-bats.sh
-    - run: git clone --depth 1 https://github.com/bats-core/bats-support ../bats-support
+    
+    - uses: actions/checkout@v2
+      with:
+        repository: bats-core/bats-support
+        path: bats-support
+          
     # set PATh to ensure we use bats from our local installation (looking at you Mac Runner!)
     - name: bats test
       run: |
         PATH="$HOME/.local/bin:$PATH"
         bats -v
-        bats test
+        BATS_LIB_PATH="$PWD" bats test

--- a/test/70-temp-10-temp_make.bats
+++ b/test/70-temp-10-temp_make.bats
@@ -51,10 +51,8 @@ fixtures 'temp'
   run bats "${TEST_FIXTURE_ROOT}/temp_make-main.bats"
 
   [ "$status" -eq 1 ]
-  [ "${#lines[@]}" -eq 9 ]
-  [ "${lines[5]}" == '# -- ERROR: temp_make --' ]
-  [ "${lines[6]}" == "# Must be called from \`setup', \`@test' or \`teardown'" ]
-  [ "${lines[7]}" == '# --' ]
+  [[ "${output}" == *'-- ERROR: temp_make --'* ]] || false
+  [[ "${output}" == *"Must be called from \`setup', \`@test' or \`teardown'"* ]] || false
 }
 
 # Options

--- a/test/70-temp-11-temp_del.bats
+++ b/test/70-temp-11-temp_del.bats
@@ -37,7 +37,8 @@ fixtures 'temp'
   [ "${lines[0]}" == '-- ERROR: temp_del --' ]
   # Travis CI's Ubuntu 12.04, quotes the path with a backtick and an
   # apostrophe, instead of just apostrophes.
-  [[ ${lines[1]} =~ 'rm: cannot remove '.${path}.': No such file or directory' ]]
+  local REGEX="rm: can(no|')t remove '${path}': No such file or directory"
+  [[ ${lines[1]} =~ $REGEX ]] || false
   [ "${lines[2]}" == '--' ]
 }
 
@@ -122,10 +123,8 @@ fixtures 'temp'
   run bats "${TEST_FIXTURE_ROOT}/temp_del-main.bats"
 
   [ "$status" -eq 1 ]
-  [ "${#lines[@]}" -eq 10 ]
-  [ "${lines[6]}" == '# -- ERROR: temp_del --' ]
-  [ "${lines[7]}" == "# Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'" ]
-  [ "${lines[8]}" == '# --' ]
+  [[ "$output" == *'-- ERROR: temp_del --'* ]] || false
+  [[ "$output" == *"Must be called from \`teardown' or \`teardown_file' when using \`BATSLIB_TEMP_PRESERVE_ON_FAILURE'"* ]] || false
 }
 
 @test "temp_del() <path>: \`BATSLIB_TEMP_PRESERVE_ON_FAILURE' does not work when called from \`setup'" {

--- a/test/70-temp-11-temp_del.bats
+++ b/test/70-temp-11-temp_del.bats
@@ -37,8 +37,7 @@ fixtures 'temp'
   [ "${lines[0]}" == '-- ERROR: temp_del --' ]
   # Travis CI's Ubuntu 12.04, quotes the path with a backtick and an
   # apostrophe, instead of just apostrophes.
-  local REGEX="rm: can(no|')t remove '${path}': No such file or directory"
-  [[ ${lines[1]} =~ $REGEX ]] || false
+  [[ ${lines[1]} == 'rm:'*"${path}"*': No such file or directory' ]] || false
   [ "${lines[2]}" == '--' ]
 }
 

--- a/test/fixtures/temp/test_helper.bash
+++ b/test/fixtures/temp/test_helper.bash
@@ -2,7 +2,7 @@ export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/../../.."
 export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
 
 # Load dependencies.
-load "${TEST_DEPS_DIR}/bats-support/load.bash"
+bats_load_library "bats-support"
 
 # Load library.
 load "${TEST_MAIN_DIR}/load.bash"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -20,6 +20,6 @@ export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
 set -u
 
 # Load dependencies.
-load "${TEST_DEPS_DIR}/bats-support/load.bash"
+bats_load_library 'bats-support'
 # Load library.
 load '../load'


### PR DESCRIPTION
Similarly to https://github.com/bats-core/bats-assert/pull/49, instead of assuming that `bats-support` is in an adjacent directory, use the `bats_load_library` command to load it.

`bats_load_library` is available since Bats v1.6.

Tested by running `bats test` on a Debian system with the `bats-support` package installed (all tests load fine but some fail due an unrelated issue).