### PR TITLE
src/file.bash: Align code of `assert_not_file_owner` to `assert_file_owner`

### DIFF
--- a/src/file.bash
+++ b/src/file.bash
@@ -816,20 +816,23 @@ assert_file_not_executable() {
 # Outputs:
 #   STDERR - details, on failure
 assert_not_file_owner() {
-  local -r owner="$1"
+  local -r expected_owner="$1"
   local -r file="$2"
-  if [[ "$(uname)" == "Darwin" ]]; then
-    __cmd_param="-f %Su"
-  elif [[ "$(uname)" == "Linux" ]]; then
-    __cmd_param="-c %U"
-  fi
-  __o=$(stat $__cmd_param "$file")
+  case "$OSTYPE" in
+    "darwin"*)
+      local -ra  cmd_params=(-f %Su)
+    ;;
+    "linux-gnu"*)
+      local -ra cmd_params=(-c %U)
+    ;;
+  esac
+  local -r actual_owner=$(stat "${cmd_params[@]}" "$file")
 
-  if [[ "$__o" == "$owner" ]]; then
+  if [[ "$actual_owner" == "$expected_owner" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
     local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
-      | batslib_decorate "user $owner is the owner of the file, but it was expected not to be" \
+      | batslib_decorate "user $expected_owner is the owner of the file, but it was expected not to be" \
       | fail
   fi
 }

--- a/src/file.bash
+++ b/src/file.bash
@@ -818,27 +818,20 @@ assert_file_not_executable() {
 assert_not_file_owner() {
   local -r owner="$1"
   local -r file="$2"
-  if [[ `uname` == "Darwin" ]]; then
-  sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
-  sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
-  if [ `stat -f '%Su' "$file"` = "$owner" ]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    __cmd_param="-f %Su"
+  elif [[ "$(uname)" == "Linux" ]]; then
+    __cmd_param="-c %U"
+  fi
+  __o=$(stat $__cmd_param "$file")
+
+  if [[ "$__o" == "$owner" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
     local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
-      | batslib_decorate "given user is the $owner, but it was expected not to be" \
+      | batslib_decorate "user $owner is the owner of the file, but it was expected not to be" \
       | fail
   fi
-  elif [[ `uname` == "Linux" ]]; then
-  sudo chown root ${TEST_FIXTURE_ROOT}/dir/owner
-  sudo chown daemon ${TEST_FIXTURE_ROOT}/dir/notowner
-    if [ `stat -c "%U" "$file"` = "$owner" ]; then
-    local -r rem="${BATSLIB_FILE_PATH_REM-}"
-    local -r add="${BATSLIB_FILE_PATH_ADD-}"
-    batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
-      | batslib_decorate "given user is the $owner, but it was expected not to be" \
-      | fail
-  fi
-fi
 }
 
 # Fail if the file has given permissions. This

--- a/src/file.bash
+++ b/src/file.bash
@@ -267,6 +267,24 @@ assert_files_equal() {
   fi
 }
 
+# Get the owner of a file
+# Arguments:
+# $1 - output variable name
+# $2 - path to file
+_bats_get_file_owner() {
+  local -r output_var=$1
+  local -r file=$2
+  case "$OSTYPE" in
+    "darwin"*)
+      local -ra cmd_params=(-f %Su)
+    ;;
+    "linux-gnu"*)
+      local -ra cmd_params=(-c %U)
+    ;;
+  esac
+  printf -v "$output_var" "%s" "$(stat "${cmd_params[@]}" "$file")"
+}
+
 # Fail and display path of the user is not the owner of a file. This
 # function is the logical complement of `assert_file_not_owner'.
 #
@@ -283,14 +301,12 @@ assert_files_equal() {
 assert_file_owner() {
   local -r owner="$1"
   local -r file="$2"
-  if [[ "$(uname)" == "Darwin" ]]; then
-    __cmd_param="-f %Su"
-  elif [[ "$(uname)" == "Linux" ]]; then
-    __cmd_param="-c %U"
-  fi
-  __o=$(stat $__cmd_param "$file")
+  
+  local actual_owner
+  _bats_get_file_owner actual_owner "$file"
+  readonly actual_owner
 
-  if [[ "$__o" != "$owner" ]]; then
+  if [[ "$actual_owner" != "$owner" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
     local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
@@ -818,15 +834,10 @@ assert_file_not_executable() {
 assert_not_file_owner() {
   local -r expected_owner="$1"
   local -r file="$2"
-  case "$OSTYPE" in
-    "darwin"*)
-      local -ra  cmd_params=(-f %Su)
-    ;;
-    "linux-gnu"*)
-      local -ra cmd_params=(-c %U)
-    ;;
-  esac
-  local -r actual_owner=$(stat "${cmd_params[@]}" "$file")
+
+  local actual_owner
+  _bats_get_file_owner actual_owner "$file"
+  readonly actual_owner
 
   if [[ "$actual_owner" == "$expected_owner" ]]; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"

--- a/test/59-assert-11-assert_not_file_owner.bats
+++ b/test/59-assert-11-assert_not_file_owner.bats
@@ -37,13 +37,13 @@ teardown () {
   [ "${#lines[@]}" -eq 0 ]
 }
 
-@test 'assert_not_file_owner() <file>: returns 1 and displays path if <file> given user is the root, but it was expected not to be' {
+@test 'assert_not_file_owner() <file>: returns 1 and displays path if <file> user root is the owner of the file, but it was expected not to be' {
   local -r owner="root"
   local -r file="${TEST_FIXTURE_ROOT}/dir/owner"
   run assert_not_file_owner "$owner" "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- given user is the root, but it was expected not to be --' ]
+  [ "${lines[0]}" == '-- user root is the owner of the file, but it was expected not to be --' ]
   [ "${lines[1]}" == "path : $file" ]
   [ "${lines[2]}" == '--' ]
 }
@@ -58,7 +58,7 @@ teardown () {
   run assert_not_file_owner "$owner" "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- given user is the root, but it was expected not to be --' ]
+  [ "${lines[0]}" == '-- user root is the owner of the file, but it was expected not to be --' ]
   [ "${lines[1]}" == "path : ../dir/owner" ]
   [ "${lines[2]}" == '--' ]
 }
@@ -71,7 +71,7 @@ teardown () {
   run assert_not_file_owner "$owner" "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- given user is the root, but it was expected not to be --' ]
+  [ "${lines[0]}" == '-- user root is the owner of the file, but it was expected not to be --' ]
   [ "${lines[1]}" == "path : ${TEST_FIXTURE_ROOT}/.." ]
   [ "${lines[2]}" == '--' ]
 }
@@ -84,7 +84,7 @@ teardown () {
   run assert_not_file_owner "$owner" "$file"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" == '-- given user is the root, but it was expected not to be --' ]
+  [ "${lines[0]}" == '-- user root is the owner of the file, but it was expected not to be --' ]
   [ "${lines[1]}" == "path : ${TEST_FIXTURE_ROOT}/.." ]
   [ "${lines[2]}" == '--' ]
 }


### PR DESCRIPTION
Change the code of `assert_not_file_owner` to the version of `assert_file_owner` introduced in PR #38.

The removal of the stray sudo calls fixes issue #49.