### PR TITLE
test/60-assert: Remove superfluous sudo

### DIFF
--- a/test/60-assert-10-assert_file_permission.bats
+++ b/test/60-assert-10-assert_file_permission.bats
@@ -5,7 +5,7 @@ fixtures 'exist'
 
 setup () {
   touch ${TEST_FIXTURE_ROOT}/dir/permission
-  sudo chmod 777 ${TEST_FIXTURE_ROOT}/dir/permission
+  chmod 777 ${TEST_FIXTURE_ROOT}/dir/permission
 }
 teardown () {
   

--- a/test/60-assert-10-assert_file_permission.bats
+++ b/test/60-assert-10-assert_file_permission.bats
@@ -8,7 +8,6 @@ setup () {
   chmod 777 ${TEST_FIXTURE_ROOT}/dir/permission
 }
 teardown () {
-  
   rm -f ${TEST_FIXTURE_ROOT}/dir/permission
 }
 

--- a/test/60-assert-11-assert_file_no_permissions.bats
+++ b/test/60-assert-11-assert_file_no_permissions.bats
@@ -9,7 +9,6 @@ setup () {
   chmod 644 ${TEST_FIXTURE_ROOT}/dir/nopermission
 }
 teardown () {
-  
   rm -f ${TEST_FIXTURE_ROOT}/dir/permission ${TEST_FIXTURE_ROOT}/dir/nopermission
 }
 

--- a/test/60-assert-11-assert_file_no_permissions.bats
+++ b/test/60-assert-11-assert_file_no_permissions.bats
@@ -5,8 +5,8 @@ fixtures 'exist'
 
 setup () {
   touch ${TEST_FIXTURE_ROOT}/dir/permission ${TEST_FIXTURE_ROOT}/dir/nopermission
-  sudo chmod 777 ${TEST_FIXTURE_ROOT}/dir/permission 
-  sudo chmod 644 ${TEST_FIXTURE_ROOT}/dir/nopermission
+  chmod 777 ${TEST_FIXTURE_ROOT}/dir/permission
+  chmod 644 ${TEST_FIXTURE_ROOT}/dir/nopermission
 }
 teardown () {
   


### PR DESCRIPTION
The `chmod` command operates on files that are created by `touch` in the same environment. If `touch` succeeded, then `sudo` is not necessary to change the permission of the files.