### PR TITLE
test: Move calculation of sudo path to a shared function

### DIFF
--- a/test/54-assert-10-assert_character_exists.bats
+++ b/test/54-assert-10-assert_character_exists.bats
@@ -4,7 +4,7 @@ load 'test_helper'
 fixtures 'exist'
 
 setup () {
- sudo mknod ${TEST_FIXTURE_ROOT}/dir/test_device c 89 1
+  bats_sudo mknod ${TEST_FIXTURE_ROOT}/dir/test_device c 89 1
 }
 teardown () {
     rm -f ${TEST_FIXTURE_ROOT}/dir/test_device

--- a/test/54-assert-11-assert_character_not_exists.bats
+++ b/test/54-assert-11-assert_character_not_exists.bats
@@ -4,7 +4,7 @@ load 'test_helper'
 fixtures 'exist'
 
 setup () {
- sudo mknod ${TEST_FIXTURE_ROOT}/dir/test_device c 89 1
+  bats_sudo mknod ${TEST_FIXTURE_ROOT}/dir/test_device c 89 1
 }
 teardown () {
     rm -f ${TEST_FIXTURE_ROOT}/dir/test_device

--- a/test/55-assert-10-assert_block_exists.bats
+++ b/test/55-assert-10-assert_block_exists.bats
@@ -3,7 +3,7 @@ load 'test_helper'
 fixtures 'exist'
 
 setup () {
- sudo mknod ${TEST_FIXTURE_ROOT}/dir/blockfile b 89 1
+  bats_sudo mknod ${TEST_FIXTURE_ROOT}/dir/blockfile b 89 1
 }
 teardown () {
     rm -f ${TEST_FIXTURE_ROOT}/dir/blockfile

--- a/test/55-assert-11-assert_block_not_exists.bats
+++ b/test/55-assert-11-assert_block_not_exists.bats
@@ -4,7 +4,7 @@ load 'test_helper'
 fixtures 'exist'
 
 setup () {
- sudo mknod ${TEST_FIXTURE_ROOT}/dir/blockfile b 89 1
+  bats_sudo mknod ${TEST_FIXTURE_ROOT}/dir/blockfile b 89 1
 }
 teardown () {
     rm -f ${TEST_FIXTURE_ROOT}/dir/blockfile

--- a/test/59-assert-10-assert_file_owner.bats
+++ b/test/59-assert-10-assert_file_owner.bats
@@ -5,27 +5,15 @@ fixtures 'exist'
 
 setup () {
   touch ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
-  sudo_path=$(command -v sudo 2>/dev/null)
   # There is PATH addition to /usr/sbin which won't come by default on bash3
   # on macOS
   chown_path=$(PATH="$PATH:/usr/sbin" command -v chown 2>/dev/null)
-  if [[ "$(whoami)" != 'root' ]] && [ -x "$sudo_path" ]; then
-    __cmd="$sudo_path $chown_path"
-  else
-    __cmd="$chown_path"
-  fi
-  $__cmd root ${TEST_FIXTURE_ROOT}/dir/owner
-  $__cmd daemon ${TEST_FIXTURE_ROOT}/dir/notowner
+  bats_sudo "$chown_path" root ${TEST_FIXTURE_ROOT}/dir/owner
+  bats_sudo "$chown_path" daemon ${TEST_FIXTURE_ROOT}/dir/notowner
 }
 
 teardown () {
-  sudo_path=$(command -v sudo 2>/dev/null)
-  if [[ "$(whoami)" != 'root' ]] && [ -x "$sudo_path" ]; then
-    __cmd="$sudo_path rm -f"
-  else
-    __cmd="rm -f"
-  fi
-  $__cmd ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
+  bats_sudo rm -f ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
 }
 
 # Correctness

--- a/test/59-assert-11-assert_not_file_owner.bats
+++ b/test/59-assert-11-assert_not_file_owner.bats
@@ -5,27 +5,15 @@ fixtures 'exist'
 
 setup () {
   touch ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
-  sudo_path=$(command -v sudo 2>/dev/null)
   # There is PATH addition to /usr/sbin which won't come by default on bash3
   # on macOS
   chown_path=$(PATH="$PATH:/usr/sbin" command -v chown 2>/dev/null)
-  if [[ "$(whoami)" != 'root' ]] && [ -x "$sudo_path" ]; then
-    __cmd="$sudo_path $chown_path"
-  else
-    __cmd="$chown_path"
-  fi
-  $__cmd root ${TEST_FIXTURE_ROOT}/dir/owner
-  $__cmd daemon ${TEST_FIXTURE_ROOT}/dir/notowner
+  bats_sudo "$chown_path" root ${TEST_FIXTURE_ROOT}/dir/owner
+  bats_sudo "$chown_path" daemon ${TEST_FIXTURE_ROOT}/dir/notowner
 }
 
 teardown () {
-  sudo_path=$(command -v sudo 2>/dev/null)
-  if [[ "$(whoami)" != 'root' ]] && [ -x "$sudo_path" ]; then
-    __cmd="$sudo_path rm -f"
-  else
-    __cmd="rm -f"
-  fi
-  $__cmd ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
+  bats_sudo rm -f ${TEST_FIXTURE_ROOT}/dir/owner ${TEST_FIXTURE_ROOT}/dir/notowner
 }
 
 # Correctness

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,6 +13,15 @@ fixtures() {
   TEST_RELATIVE_FIXTURE_ROOT=$(bats_trim_filename "${TEST_FIXTURE_ROOT}" TEST_RELATIVE_FIXTURE_ROOT)
 }
 
+bats_sudo() {
+  local sudo_path=$(command -v sudo 2>/dev/null)
+  if [[ "$(whoami)" != 'root' ]] && [ -x "$sudo_path" ]; then
+    "$sudo_path" "$@"
+  else
+    "$@"
+  fi
+}
+
 export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/.."
 export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/..}"
 


### PR DESCRIPTION
Many tests use a duplicated snippet of code to check if it is needed to prefix certain commands with `sudo` and to find out the full path of the `sudo` executable.

Moving all these snippets to a shared function simplifies the tests and provides a single point to patch to integrate these tests in environments where finding the path of `sudo` (or of a `sudo`-like command) is non trivial, for example inside the Debian testing infrastructure.