### PR TITLE
assert_file_contains: print regex on error

### DIFF
--- a/src/file.bash
+++ b/src/file.bash
@@ -543,7 +543,7 @@ assert_file_contains() {
   if ! grep -q "$regex" "$file"; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
     local -r add="${BATSLIB_FILE_PATH_ADD-}"
-    batslib_print_kv_single 4 'path' "${file/$rem/$add}" \
+    batslib_print_kv_single 4 'path' "${file/$rem/$add}" 'regex' "$regex" \
       | batslib_decorate 'file does not contain regex' \
       | fail
   fi

--- a/test/67-assert-10-assert_file_contains.bats
+++ b/test/67-assert-10-assert_file_contains.bats
@@ -31,3 +31,16 @@ fixtures 'empty'
   run assert_file_contains "${TEST_FIXTURE_ROOT}/dir/non-empty-file" "XXX"
   [ "$status" -eq 1 ]
 }
+@test 'assert_file_contains() <file>: show missing regex in case of failure' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/non-empty-file"
+  run assert_file_contains "$file" "XXX"
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" == '-- file does not contain regex --' ]
+  [ "${lines[1]}" == "path : $file" ]
+  [ "${lines[2]}" == "regex : XXX" ]
+  [ "${lines[3]}" == '--' ]
+}
+
+
+  


### PR DESCRIPTION
In case of assertion failure, seeing the missing regex in the test output is helpful.

This PR change the `assert_file_contains /home/test/file1.txt regex1` output from:

```
   -- file does not contain regex --
   path : /home/test/file1.txt
   --
```

to 
```
   -- file does not contain regex --
   path : /home/test/file1.txt
   regex : regex1
   --
```


