### PR TITLE
feat: adds the missing assert_file_not_contains function

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['macos-10.15', 'ubuntu-latest']
+        os: ['macos-12', 'ubuntu-latest']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ load this library.
 | Test File Types | Test File Attributes | Test File Content |
 | ----------- | ----------- | ----------- |
 | _Check if a **file or directory** exists!_ <br/> - [assert_exists](#assert_exists) <br/> - [assert_not_exists](#assert_not_exists) | _Check if file is **executable**!_ <br/> - [assert_file_executable](#assert_file_executable) <br/> - [assert_file_not_executable](#assert_file_not_executable) | _Check if file is **empty**!_ <br/> - [assert_file_empty](#assert_file_empty) <br/> - [assert_file_not_empty](#assert_file_not_empty) |
-| _Check if a **file** exists!_ <br/> - [assert_file_exists](#assert_file_exists) <br/> - [assert_file_not_exists](#assert_file_not_exists) | _Check the **owner** of a file!_ <br/> - [assert_file_owner](#assert_file_owner) <br/> - [assert_file_not_owner](#assert_file_not_owner) | _Check if file **contains regex**!_ <br/>  - [assert_file_contains](#assert_file_contains) <br/> - ~~assert_file_not_contains~~ |
+| _Check if a **file** exists!_ <br/> - [assert_file_exists](#assert_file_exists) <br/> - [assert_file_not_exists](#assert_file_not_exists) | _Check the **owner** of a file!_ <br/> - [assert_file_owner](#assert_file_owner) <br/> - [assert_file_not_owner](#assert_file_not_owner) | _Check if file **contains regex**!_ <br/>  - [assert_file_contains](#assert_file_contains) <br/> - [assert_file_not_contains](#assert_file_not_contains) |
 | _Check if a **directory** exists!_ <br/> - [assert_dir_exists](#assert_dir_exists) <br/> - [assert_dir_not_exists](#assert_dir_not_exists) | _Check the **permission** of a file!_ <br/> - [assert_file_permission](#assert_file_permission) <br/> - [assert_not_file_permission](#assert_not_file_permission) | _Check if file is a **symlink to target**!_ <br/> - [assert_symlink_to](#assert_symlink_to) <br/> - [assert_not_symlink_to](#assert_not_symlink_to) |
 | _Check if a **link** exists!_ <br/> - [assert_link_exists](#assert_link_exists) <br/> - [assert_link_not_exists](#assert_link_not_exists) | _Check the **size** of a file **by bytes**!_ <br/> - [assert_file_size_equals](#assert_file_size_equals) |
 | _Check if a **block special file** exists!_ <br/> - [assert_block_exists](#assert_block_exists) <br/> - [assert_block_not_exists](#assert_block_not_exists) | _Check if a file have **zero bytes**!_ <br/> - [assert_size_zero](#assert_size_zero) <br/> - [assert_size_not_zero](#assert_size_not_zero) |
@@ -743,6 +743,19 @@ Fail if the given file does not contain the regex.
 }
 ```
 On failure, the path and expected regex are displayed.
+
+[Back to index](#Index-of-all-functions)
+
+---
+
+### `assert_file_not_contains`
+Fail if the given file contains the regex.
+```bash
+@test 'assert_file_not_contains() {
+    assert_file_not_contains /path/to/non-empty-file regex
+}
+```
+On failure, the path and regex are displayed.
 
 [Back to index](#Index-of-all-functions)
 

--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ On failure, the path and expected regex are displayed.
 ---
 
 ### `assert_file_not_contains`
-Fail if the given file contains the regex.
+Fail if the given file contains the regex or if the file does not exist.
 ```bash
 @test 'assert_file_not_contains() {
     assert_file_not_contains /path/to/non-empty-file regex

--- a/src/file.bash
+++ b/src/file.bash
@@ -565,12 +565,21 @@ assert_file_contains() {
 assert_file_not_contains() {
   local -r file="$1"
   local -r regex="$2"
-  if grep -q "$regex" "$file"; then
+
+  if [[ ! -f "$file" ]]; then
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
+    batslib_print_kv_single 4 'path' "${file/$rem/$add}" 'regex' "$regex" \
+      | batslib_decorate 'file does not exist' \
+      | fail
+  
+  elif grep -q "$regex" "$file"; then
     local -r rem="${BATSLIB_FILE_PATH_REM-}"
     local -r add="${BATSLIB_FILE_PATH_ADD-}"
     batslib_print_kv_single 4 'path' "${file/$rem/$add}" 'regex' "$regex" \
       | batslib_decorate 'file contains regex' \
       | fail
+
   fi
 }
 # Fail and display path of the file (or directory) if it is not empty.

--- a/src/file.bash
+++ b/src/file.bash
@@ -548,6 +548,31 @@ assert_file_contains() {
       | fail
   fi
 }
+# Fail and display path of the file (or directory) if it does contain a string.
+# This function is the logical complement of `assert_file_contains'.
+#
+# Globals:
+#   BATSLIB_FILE_PATH_REM
+#   BATSLIB_FILE_PATH_ADD
+# Arguments:
+#   $1 - path
+#   $2 - regex
+# Returns:
+#   0 - file does not contain regex
+#   1 - otherwise
+# Outputs:
+#   STDERR - details, on failure
+assert_file_not_contains() {
+  local -r file="$1"
+  local -r regex="$2"
+  if grep -q "$regex" "$file"; then
+    local -r rem="${BATSLIB_FILE_PATH_REM-}"
+    local -r add="${BATSLIB_FILE_PATH_ADD-}"
+    batslib_print_kv_single 4 'path' "${file/$rem/$add}" 'regex' "$regex" \
+      | batslib_decorate 'file contains regex' \
+      | fail
+  fi
+}
 # Fail and display path of the file (or directory) if it is not empty.
 # This function is the logical complement of `assert_file_not_empty'.
 #

--- a/test/67-assert-10-assert_file_not_contains.bats
+++ b/test/67-assert-10-assert_file_not_contains.bats
@@ -36,7 +36,7 @@ fixtures 'empty'
   run assert_file_not_contains "$file" "Not empty"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 4 ]
-  [ "${lines[0]}" == '-- file does not contain regex --' ]
+  [ "${lines[0]}" == '-- file contains regex --' ]
   [ "${lines[1]}" == "path : $file" ]
   [ "${lines[2]}" == "regex : Not empty" ]
   [ "${lines[3]}" == '--' ]

--- a/test/67-assert-10-assert_file_not_contains.bats
+++ b/test/67-assert-10-assert_file_not_contains.bats
@@ -41,3 +41,15 @@ fixtures 'empty'
   [ "${lines[2]}" == "regex : Not empty" ]
   [ "${lines[3]}" == '--' ]
 }
+@test 'assert_file_not_contains() <file>: returns 1 and displays path if <file> does not exist' {
+  local -r file="${TEST_FIXTURE_ROOT}/missing"
+  run assert_file_not_contains "$file" "XXX"
+  echo "status: $status"
+  echo "output: $output"
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" == '-- file does not exist --' ]
+  [ "${lines[1]}" == "path : $file" ]
+  [ "${lines[2]}" == "regex : XXX" ]
+  [ "${lines[3]}" == '--' ]
+}

--- a/test/67-assert-10-assert_file_not_contains.bats
+++ b/test/67-assert-10-assert_file_not_contains.bats
@@ -44,8 +44,6 @@ fixtures 'empty'
 @test 'assert_file_not_contains() <file>: returns 1 and displays path if <file> does not exist' {
   local -r file="${TEST_FIXTURE_ROOT}/missing"
   run assert_file_not_contains "$file" "XXX"
-  echo "status: $status"
-  echo "output: $output"
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 4 ]
   [ "${lines[0]}" == '-- file does not exist --' ]

--- a/test/67-assert-10-assert_file_not_contains.bats
+++ b/test/67-assert-10-assert_file_not_contains.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+load 'test_helper'
+fixtures 'empty'
+# Correctness
+@test 'assert_file_not_contains() <file>: returns 0 and displays content if <file> does not match string' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/non-empty-file"
+  run assert_file_not_contains "$file" "XXX"
+  [ "$status" -eq 0 ]
+}
+@test 'assert_file_not_contains() <file>: returns 1 and displays content if <file> does match string' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/non-empty-file"
+  run assert_file_not_contains "$file" "Not empty"
+  [ "$status" -eq 1 ]
+}
+# Transforming path
+@test 'assert_file_not_contains() <file>: replace prefix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM="#${TEST_FIXTURE_ROOT}"
+  local -r BATSLIB_FILE_PATH_ADD='..'
+  run assert_file_not_contains "${TEST_FIXTURE_ROOT}/dir/non-empty-file" "Not empty"
+  [ "$status" -eq 1 ]
+}
+@test 'assert_file_not_contains() <file>: replace suffix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM='%non-empty-file'
+  local -r BATSLIB_FILE_PATH_ADD='..'
+  run assert_file_not_contains "${TEST_FIXTURE_ROOT}/dir/non-empty-file" "Not empty"
+  [ "$status" -eq 1 ]
+}
+@test 'assert_file_not_contains() <file>: replace infix of displayed path' {
+  local -r BATSLIB_FILE_PATH_REM='dir'
+  local -r BATSLIB_FILE_PATH_ADD='..'
+  run assert_file_not_contains "${TEST_FIXTURE_ROOT}/dir/non-empty-file" "Not empty"
+  [ "$status" -eq 1 ]
+}
+@test 'assert_file_not_contains() <file>: show missing regex in case of failure' {
+  local -r file="${TEST_FIXTURE_ROOT}/dir/non-empty-file"
+  run assert_file_not_contains "$file" "Not empty"
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" == '-- file does not contain regex --' ]
+  [ "${lines[1]}" == "path : $file" ]
+  [ "${lines[2]}" == "regex : Not empty" ]
+  [ "${lines[3]}" == '--' ]
+}


### PR DESCRIPTION
I needed to use this method and I noticed the open issue that it does not yet exist. Added the `assert_file_not_contains` method and tests that are basically just the exact opposities of the `assert_file_contains` tests.