### PR TITLE
tests: Update github config to use current macos and actions/checkout, fixes #68

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,23 +13,23 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: shellcheck ./src/*
   build:
     strategy:
       matrix:
-        os: ['macos-12', 'ubuntu-latest']
+        os: ['macos-15', 'ubuntu-latest']
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: ./script/install-bats.sh
-    
-    - uses: actions/checkout@v2
+
+    - uses: actions/checkout@v4
       with:
         repository: bats-core/bats-support
         path: bats-support
-          
+
     # set PATh to ensure we use bats from our local installation (looking at you Mac Runner!)
     - name: bats test
       run: |


### PR DESCRIPTION
Github tests:

* Use current macos version instead of deprecated
* Use current actions/checkout